### PR TITLE
Add support for 'mum' swapping

### DIFF
--- a/myscript.js
+++ b/myscript.js
@@ -728,6 +728,15 @@ var map = {
     "ACTRESSES" : "ACTORS"
 };
 
+if ( mother_short == 'mum' ) {
+    map['mum'] = 'dad';
+    map['Mum'] = 'Dad';
+    map['MUM'] = 'DAD';
+    map['mums'] = 'dads';
+    map['Mums'] = 'Dads';
+    map['MUMS'] = 'DADS';
+}
+
 function genderswap(text){
     text = text.replace(searchFor, function(match) {
         var replacement;


### PR DESCRIPTION
Hello,

I've added support for swapping "mum" into "dad". However "dad" is currently left at being swapped into "mom".

For example here's a UK news article using "mum". When I first saw this it was "The day Mom attacked Mum with an axe" which is obviously odd. http://www.guardian.co.uk/lifeandstyle/2011/nov/14/dad-attacked-mum-with-axe

I'm not sure what you wanna do with this, feel free to not merge it into your branch, since for N. American english it 'mum' is probably only used for "mum's the word" etc., whereas here in Europe it's used entirely instead of "Mom". There might be a way to look at the users prefered language (en-gb vs en-us) and make a better call then. I'll look into that & update this branch if possible.
