### PR TITLE
Jailbreak title

### DIFF
--- a/myscript.js
+++ b/myscript.js
@@ -764,6 +764,12 @@ function jailbreak(node){
 chrome.extension.sendRequest({checkPaused: "hello"}, function(response) {
     if (response.maybePaused!="yes") {
     jailbreak(document.body);
+    var titles = document.getElementsByTagName("title");
+    for( tag in titles ) {
+        try {
+            jailbreak(titles[tag]);
+        } catch(err) {}
+    }
 
     document.body.addEventListener('DOMNodeInserted', function(event) {
         jailbreak(event.target);


### PR DESCRIPTION
Apply text substitution to the <title> tag of documents aswell.

This is less important cause the title isn't shown much on chrome, but it's good to be consistant.
