### PR TITLE
Refactor case handling and him/her swapping

### DIFF
--- a/myscript.js
+++ b/myscript.js
@@ -269,7 +269,6 @@ function matchCase(word, orig) {
 
 function swapWord(word) {
   var replacement = map[word.toLowerCase()];
-  console.log('swapping', word, replacement);
   return replacement ? matchCase(replacement, word) : word;
 }
 


### PR DESCRIPTION
Sorry for the giant diff, but it all sort of happened in one go :).

Things that this eliminates the need for:
- the giant searchFor regex
- the differently-cased copies of the map (only lowercase is now needed,
  with the matchCase helper)
- the keyboard-mashing replacement strings (each instance is handled
  separately instead).

This is awesome, btw. :)
